### PR TITLE
Feature/unicode fixes

### DIFF
--- a/didata_cli/commands/cmd_network.py
+++ b/didata_cli/commands/cmd_network.py
@@ -53,7 +53,7 @@ def create_vlan(client, networkdomainid, name, baseipv4address, description, pre
 
 
 @cli.command()
-@click.option('--vlanId', required=True, help="ID of the vlan to remove")
+@click.option('--vlanId', type=click.UNPROCESSED, required=True, help="ID of the vlan to remove")
 @pass_client
 def delete_vlan(client, vlanid):
     try:
@@ -100,7 +100,7 @@ def create_network_domain(client, datacenterid, name, serviceplan, description):
 
 
 @cli.command()
-@click.option('--networkDomainId', required=True, help="ID of the network domain to remove")
+@click.option('--networkDomainId', type=click.UNPROCESSED, required=True, help="ID of the network domain to remove")
 @pass_client
 def delete_network_domain(client, networkdomainid):
     try:
@@ -145,7 +145,7 @@ def list_networks(client, datacenterid):
 
 
 @cli.command()
-@click.option('--networkId', required=True, help="ID of the network to remove")
+@click.option('--networkId', type=click.UNPROCESSED, required=True, help="ID of the network to remove")
 @pass_client
 def delete_network(client, networkid):
     try:
@@ -158,7 +158,7 @@ def delete_network(client, networkid):
 @cli.command()
 @click.option('--name', required=True, help="Name for the rule")
 @click.option('--action', required=True, type=click.Choice(['ACCEPT_DECISIVELY', 'DROP']))
-@click.option('--networkId', required=True, help="The network domain to apply the rule to")
+@click.option('--networkId', type=click.UNPROCESSED, required=True, help="The network domain to apply the rule to")
 @click.option('--ipVersion', required=True, type=click.Choice(['IPV4', 'IPV6']))
 @click.option('--protocol', required=True, type=click.Choice(['IP', 'ICMP', 'TCP', 'UDP']))
 @click.option('--sourceIP', required=True, help="ANY or valid IPv4/IPv6 address")
@@ -195,7 +195,7 @@ def create_firewall_rule(client, name, action, networkid, ipversion, protocol, s
 
 
 @cli.command()
-@click.option('--networkId', required=True, help="Network Domain ID where the rules live")
+@click.option('--networkId', type=click.UNPROCESSED, required=True, help="Network Domain ID where the rules live")
 @pass_client
 def list_firewall_rules(client, networkid):
     try:
@@ -219,8 +219,8 @@ def list_firewall_rules(client, networkid):
 
 
 @cli.command()
-@click.option('--networkId', required=True, help="ID of the network where the firewall rule lives")
-@click.option('--ruleId', required=True, help="ID of the fireall rule to remove")
+@click.option('--networkId', type=click.UNPROCESSED, required=True, help="Network ID where the firewall rule lives")
+@click.option('--ruleId', type=click.UNPROCESSED, required=True, help="ID of the fireall rule to remove")
 @pass_client
 def delete_firewall_rule(client, networkid, ruleid):
     try:

--- a/didata_cli/commands/cmd_server.py
+++ b/didata_cli/commands/cmd_server.py
@@ -77,7 +77,7 @@ def list(client, datacenterid, networkdomainid, networkid,
 @cli.command()
 @click.option('--name', required=True, help="The name of the server")
 @click.option('--description', required=True, help="The description of the server")
-@click.option('--imageId', required=True, help="The image id for the server")
+@click.option('--imageId', required=True, type=click.UNPROCESSED, help="The image id for the server")
 @click.option('--autostart', is_flag=True, default=False, help="Bool flag for if you want to autostart")
 @click.option('--administratorPassword', required=True, type=click.UNPROCESSED, help="The administrator password")
 @click.option('--networkDomainId', required=True, type=click.UNPROCESSED, help="The network domain Id to deploy on")

--- a/didata_cli/commands/cmd_server.py
+++ b/didata_cli/commands/cmd_server.py
@@ -11,10 +11,8 @@ def cli(client):
 
 
 def _print_node_info(node):
-    click.secho("{0}".format(node.name), bold=True)
+    click.secho("Name: {0}".format(node.name), bold=True)
     click.secho("ID: {0}".format(node.id))
-    click.secho("Datacenter: {0}".format(node.extra['datacenterId']))
-    click.secho("OS: {0}".format(node.extra['OS_displayName']))
     click.secho("Private IPv4: {0}".format(" - ".join(node.private_ips)))
     if 'ipv6' in node.extra:
         click.secho("Private IPv6: {0}".format(node.extra['ipv6']))
@@ -26,8 +24,17 @@ def _print_node_info(node):
             click.echo("Cores per Socket: {0}".format(node.extra[key].cores_per_socket))
             click.echo("CPU Performance: {0}".format(node.extra[key].performance))
             continue
-        if key not in ['datacenterId', 'OS_displayName']:
-            click.echo("{0}: {1}".format(key, node.extra[key]))
+        if key == 'disks':
+            for disk in node.extra[key]:
+                click.secho("Disk {0}:".format(disk.scsi_id))
+                click.secho("  Size: {0}GB".format(disk.size_gb))
+                click.secho("  Speed: {0}".format(disk.speed))
+                click.secho("  State: {0}".format(disk.state))
+            continue
+        # skip this key, it is similar to node.status
+        if key == 'status':
+            continue
+        click.echo("{0}: {1}".format(key, node.extra[key]))
     click.secho("")
 
 
@@ -41,23 +48,21 @@ def info(client, serverid):
 
 @cli.command()
 @click.option('--datacenterId', type=click.UNPROCESSED, help="Filter by datacenter Id")
-@click.option('--networkDomainId', help="Filter by network domain Id")
-@click.option('--networkId', help="Filter by network id")
-@click.option('--vlanId', help="Filter by vlan id")
-@click.option('--sourceImageId', help="Filter by source image id")
+@click.option('--networkDomainId', type=click.UNPROCESSED, help="Filter by network domain Id")
+@click.option('--networkId', type=click.UNPROCESSED, help="Filter by network id")
+@click.option('--vlanId', type=click.UNPROCESSED, help="Filter by vlan id")
+@click.option('--sourceImageId', type=click.UNPROCESSED, help="Filter by source image id")
 @click.option('--deployed', help="Filter by deployed state")
 @click.option('--name', help="Filter by server name")
 @click.option('--state', help="Filter by state")
 @click.option('--started', help="Filter by started")
 @click.option('--ipv6', help="Filter by ipv6")
 @click.option('--privateIpv4', help="Filter by private ipv4")
-@click.option('--dumpall', is_flag=True, default=False, help="Dump all attributes about the server")
 @click.option('--idsonly', is_flag=True, default=False, help="Only dump server ids")
 @pass_client
 def list(client, datacenterid, networkdomainid, networkid,
          vlanid, sourceimageid, deployed, name,
-         state, started,
-         ipv6, privateipv4, dumpall, idsonly):
+         state, started, ipv6, privateipv4, idsonly):
     node_list = client.node.list_nodes(ex_location=datacenterid, ex_name=name, ex_network=networkid,
                                        ex_network_domain=networkdomainid, ex_vlan=vlanid,
                                        ex_image=sourceimageid, ex_deployed=deployed, ex_started=started,


### PR DESCRIPTION
Added unicode fixes.
The  basestring for libcloud needs to be fixed, it's a pain that all of these have to be unprocessed as click converts everything to unicode by default.  Libcloud doesn't like unicode and fails in odd places.

Also cleaned up the server list a little bit.  Now looks like:
Name: libcloud-test
ID: 82c6970a-9413-4553-bdf5-c1ce89fcb48e
Private IPv4: 172.16.1.25
Private IPv6: 2607:f480:111:1423:3c1e:fd83:33a3:4160
Public IPs: 
State: running
OS_displayName: REDHAT6/64
OS_id: REDHAT664
OS_type: UNIX
CPU Count: 2
Cores per Socket: 1
CPU Performance: STANDARD
datacenterId: NA9
deployedTime: 2016-03-15T20:56:05.000Z
description: test node
Disk 0:
  Size: 10GB
  Speed: STANDARD
  State: NORMAL
ipv6: 2607:f480:111:1423:3c1e:fd83:33a3:4160
memoryMb: 4096
networkDomainId: 423c4386-87b4-43c4-9604-88ae237bfc7f
networkId: None
sourceImageId: eeb66fb9-be3b-44d6-bfc0-41962c974fe7
